### PR TITLE
Fix a mis-typed "context" in the specs.

### DIFF
--- a/gem_city_spec.rb
+++ b/gem_city_spec.rb
@@ -43,7 +43,7 @@ describe 'Gem City' do
     end
   end
 
-  # contex 'city_demographics' do
+  # context 'city_demographics' do
   #   it 'initialize' do
   #     demographics = city.city_demographics
   #     expect(demographics[:thieves]).to eq('10%')


### PR DESCRIPTION
Working through the code, I ran into an incorrectly typed "context"
